### PR TITLE
Use bash as make shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .EXPORT_ALL_VARIABLES:
 .PHONY: test deploy
 
+SHELL = bash
+
 VERSION = $(shell cat VERSION)
 DATE = $(shell date)
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+
 repl:
 	source ../.env && clj -A:dev -R:dev -e "(repl)" -r
 


### PR DESCRIPTION
On ubuntu make uses stricter shell by default. Some targets fail as source isn't a standard POSIX command.